### PR TITLE
[32] 배포 파일 포맷 변경

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.project.smartStore</groupId>
     <artifactId>smart-store</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <name>smart-store</name>
     <description>smart-store</description>
     <properties>


### PR DESCRIPTION
변경 이유

1. 스프링 부트는 내부 톰캣을 가지고 있어 jar로 배포 가능하다
2. jsp등을 필요로 하지 않는 Rest API 서버이기 때문에 jar로 충분하다